### PR TITLE
Atualizando a descrição do campo IVA

### DIFF
--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -2219,7 +2219,7 @@ class Danfe extends Common
 
         if (!empty($ICMS)) {
             $impostos .= $this->pDescricaoProdutoHelper($ICMS, "pRedBC", " pRedBC=%s%%");
-            $impostos .= $this->pDescricaoProdutoHelper($ICMS, "pMVAST", " IVA/MVA=%s%%");
+            $impostos .= $this->pDescricaoProdutoHelper($ICMS, "pMVAST", " MVA/IVA=%s%%");
             $impostos .= $this->pDescricaoProdutoHelper($ICMS, "pICMSST", " pIcmsSt=%s%%");
             $impostos .= $this->pDescricaoProdutoHelper($ICMS, "vBCST", " BcIcmsSt=%s");
             $impostos .= $this->pDescricaoProdutoHelper($ICMS, "vICMSST", " vIcmsSt=%s");


### PR DESCRIPTION
Atualizando a descrição do campo IVA para IVA/MVA na descrição do layout da DANFE, o motivo é que o pessoal de testes da empresa que trabalho "reclamou" por que o termo IVA não é usado aqui no PR mas sim, MVA.